### PR TITLE
fix: use VIRTUAL_ENV instead of MCP_CODER_VENV_DIR in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "code-checker": {
       "type": "stdio",
-      "command": "${MCP_CODER_VENV_DIR}\\Scripts\\mcp-code-checker.exe",
+      "command": "${VIRTUAL_ENV}\\Scripts\\mcp-code-checker.exe",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",
@@ -21,7 +21,7 @@
     },
     "filesystem": {
       "type": "stdio",
-      "command": "${MCP_CODER_VENV_DIR}\\Scripts\\mcp-server-filesystem.exe",
+      "command": "${VIRTUAL_ENV}\\Scripts\\mcp-server-filesystem.exe",
       "args": [
         "--project-dir",
         "${MCP_CODER_PROJECT_DIR}",


### PR DESCRIPTION
## Summary
- Replace `${MCP_CODER_VENV_DIR}` with the standard `${VIRTUAL_ENV}` environment variable in `.mcp.json`
- Applies to both `code-checker` and `filesystem` MCP server command paths

## Test plan
- [ ] Verify MCP servers start correctly using `VIRTUAL_ENV` to resolve the scripts directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)