### PR TITLE
fix: remove outdated MCP tool references

### DIFF
--- a/.claude/commands/rebase.md
+++ b/.claude/commands/rebase.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git add:*), Bash(git commit:*), Bash(git push --force-with-lease:*), Bash(git diff:*), Bash(git checkout --ours:*), Bash(git checkout --theirs:*), Bash(git rebase --abort:*), Bash(./tools/format_all.sh:*), Bash(mcp-coder gh-tool get-base-branch), mcp__code-checker__run_all_checks, mcp__code-checker__run_pylint_check, mcp__code-checker__run_pytest_check, mcp__code-checker__run_mypy_check, mcp__filesystem__read_file, mcp__filesystem__edit_file
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git add:*), Bash(git commit:*), Bash(git push --force-with-lease:*), Bash(git diff:*), Bash(git checkout --ours:*), Bash(git checkout --theirs:*), Bash(git rebase --abort:*), Bash(./tools/format_all.sh:*), Bash(mcp-coder gh-tool get-base-branch), mcp__code-checker__run_pylint_check, mcp__code-checker__run_pytest_check, mcp__code-checker__run_mypy_check, mcp__filesystem__read_file, mcp__filesystem__edit_file
 workflow-stage: utility
 suggested-next: (context-dependent)
 ---

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,11 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "mcp__code-checker__run_all_checks",
       "mcp__code-checker__run_pylint_check",
       "mcp__code-checker__run_pytest_check",
       "mcp__code-checker__run_mypy_check",
-      "mcp__code-checker__second_sleep",
       "mcp__filesystem__get_reference_projects",
       "mcp__filesystem__list_reference_directory",
       "mcp__filesystem__read_reference_file",


### PR DESCRIPTION
## Summary
- Remove references to `mcp__code-checker__run_all_checks` and `mcp__code-checker__second_sleep` from allowed-tools and permissions settings
- These MCP tools are no longer available/needed; the three individual check tools (`run_pylint_check`, `run_pytest_check`, `run_mypy_check`) remain

## Test plan
- [x] Verify remaining MCP tools still listed correctly in settings and commands
- [x] No code changes — only config/metadata cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)