### PR TITLE
chore(pyproject): rename from-github to install-from-github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ profile = "black"
 line_length = 88
 float_to_top = true
 
-[tool.mcp-coder.from-github]
+[tool.mcp-coder.install-from-github]
 # Installed WITH deps (leaves — picks up new external deps)
 packages = [
     "mcp-config-tool @ git+https://github.com/MarcusJellinghaus/mcp-config.git",


### PR DESCRIPTION
## Summary
- Rename `[tool.mcp-coder.from-github]` to `[tool.mcp-coder.install-from-github]` in `pyproject.toml`
- Aligns with upstream rename in mcp_coder (MarcusJellinghaus/mcp_coder#684)

Closes #85

## Test plan
- [x] Verified no source code references the old config key — change is config-only
- [x] Confirm `mcp-coder` recognizes the new key after upstream merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)