### PR TITLE
feat(mcp_workspace): add __main__ module entry point

### DIFF
--- a/src/mcp_workspace/__main__.py
+++ b/src/mcp_workspace/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running via `python -m mcp_workspace`."""
+
+from mcp_workspace.main import main
+
+main()


### PR DESCRIPTION
## Summary
Adds a `__main__.py` module to enable running the package directly via `python -m mcp_workspace`.

## Changes
- Add `__main__.py` that imports and calls `main()` from `mcp_workspace.main`