### PR TITLE
chore(config): add repo URLs and obsidian-wiki permissions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -71,7 +71,18 @@
       "Skill(implement_direct)",
       "Skill(issue_requirements)",
       "Skill(rebase)",
-      "mcp__workspace__search_files"
+      "mcp__workspace__search_files",
+      "mcp__obsidian-wiki__add-tags",
+      "mcp__obsidian-wiki__create-directory",
+      "mcp__obsidian-wiki__create-note",
+      "mcp__obsidian-wiki__delete-note",
+      "mcp__obsidian-wiki__edit-note",
+      "mcp__obsidian-wiki__list-available-vaults",
+      "mcp__obsidian-wiki__move-note",
+      "mcp__obsidian-wiki__read-note",
+      "mcp__obsidian-wiki__remove-tags",
+      "mcp__obsidian-wiki__rename-tag",
+      "mcp__obsidian-wiki__search-vault"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.mcp.json
+++ b/.mcp.json
@@ -28,13 +28,13 @@
         "--log-level",
         "DEBUG",
         "--reference-project",
-        "name=p_coder,path=${USERPROFILE}\\Documents\\GitHub\\mcp_coder",
+        "name=p_coder,path=${USERPROFILE}\\Documents\\GitHub\\mcp_coder,url=https://github.com/MarcusJellinghaus/mcp_coder",
         "--reference-project",
-        "name=p_tools,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py",
+        "name=p_tools,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py,url=https://github.com/MarcusJellinghaus/mcp-tools-py",
         "--reference-project",
-        "name=p_coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils",
+        "name=p_coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils",
         "--reference-project",
-        "name=p_config,path=${USERPROFILE}\\Documents\\GitHub\\mcp-config"
+        "name=p_config,path=${USERPROFILE}\\Documents\\GitHub\\mcp-config,url=https://github.com/MarcusJellinghaus/mcp-config"
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}\\Lib\\"


### PR DESCRIPTION
## Summary
- Add `url=` parameter to all 4 reference projects in `.mcp.json` for URL verification and lazy auto-clone support (issue #92)
- Add obsidian-wiki MCP tool permissions to `.claude/settings.local.json` (was missing, causing wiki access to be denied)

## Test plan
- [ ] Verify mcp-workspace starts without URL mismatch errors
- [ ] Verify obsidian-wiki search works in Claude Code sessions