### PR TITLE
ci: rename secret GITHUB_TEST_REPO_URL to GH_TEST_REPO_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - id: check
         env:
           TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
-          REPO_URL: ${{ secrets.GITHUB_TEST_REPO_URL }}
+          REPO_URL: ${{ secrets.GH_TEST_REPO_URL }}
         run: |
           if [[ -n "$TOKEN" && -n "$REPO_URL" ]]; then
             echo "has-secrets=true" >> $GITHUB_OUTPUT
@@ -153,7 +153,7 @@ jobs:
     name: github-integration-tests
     env:
       GITHUB_TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
-      GITHUB_TEST_REPO_URL: ${{ secrets.GITHUB_TEST_REPO_URL }}
+      GITHUB_TEST_REPO_URL: ${{ secrets.GH_TEST_REPO_URL }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Rename CI secret from `GITHUB_TEST_REPO_URL` to `GH_TEST_REPO_URL` — the `GITHUB_` prefix is not allowed for repository secrets
- The env var `GITHUB_TEST_REPO_URL` (read by Python tests) is unchanged

## Test plan
- [ ] Verify CI passes (no Python code changed)
- [ ] Create repo secret as `GH_TEST_REPO_URL` instead of `GITHUB_TEST_REPO_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)