### PR TITLE
fix: simplify editable-install check and move mcp-tools-py to deps group

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -85,7 +85,8 @@
       "mcp__obsidian-wiki__rename-tag",
       "mcp__obsidian-wiki__search-vault",
       "Bash(git checkout:*)",
-      "Bash(git pull:*)"
+      "Bash(git pull:*)",
+      "mcp__workspace__git"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/claude_local.bat
+++ b/claude_local.bat
@@ -65,20 +65,8 @@ if "!VIRTUAL_ENV!"=="" (
 )
 
 REM === Step 4: Editable install verification ===
-set "EDITABLE_OK=0"
-for /f "delims=" %%L in ('pip show mcp-workspace 2^>nul') do (
-    echo %%L | findstr /i /c:"Editable project location" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-    echo %%L | findstr /i /c:"Location:" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-)
-if "!EDITABLE_OK!"=="0" (
+"%CD%\.venv\Scripts\python.exe" -c "from importlib.metadata import distribution as D; u=D('mcp-workspace').read_text('direct_url.json') or ''; exit(0 if 'dir_info' in u and 'editable' in u else 1)" 2>nul
+if !errorlevel! NEQ 0 (
     echo WARNING: mcp-workspace does not appear to be editable-installed from %CD%
     echo   For development, run: pip install -e .
     echo   Continuing anyway...

--- a/icoder_local.bat
+++ b/icoder_local.bat
@@ -65,20 +65,8 @@ if "!VIRTUAL_ENV!"=="" (
 )
 
 REM === Step 4: Editable install verification ===
-set "EDITABLE_OK=0"
-for /f "delims=" %%L in ('pip show mcp-workspace 2^>nul') do (
-    echo %%L | findstr /i /c:"Editable project location" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-    echo %%L | findstr /i /c:"Location:" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-)
-if "!EDITABLE_OK!"=="0" (
+"%CD%\.venv\Scripts\python.exe" -c "from importlib.metadata import distribution as D; u=D('mcp-workspace').read_text('direct_url.json') or ''; exit(0 if 'dir_info' in u and 'editable' in u else 1)" 2>nul
+if !errorlevel! NEQ 0 (
     echo WARNING: mcp-workspace does not appear to be editable-installed from %CD%
     echo   For development, run: pip install -e .
     echo   Continuing anyway...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,14 +93,14 @@ line_length = 88
 float_to_top = true
 
 [tool.mcp-coder.install-from-github]
-# Installed WITH deps (leaves — picks up new external deps)
+# Installed WITH deps (picks up external deps like jedi)
 packages = [
     "mcp-config-tool @ git+https://github.com/MarcusJellinghaus/mcp-config.git",
     "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git",
-]
-# Installed WITHOUT deps (depend on siblings — avoid downgrading)
-packages-no-deps = [
     "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git",
+]
+# Installed WITHOUT deps (depends on all siblings — avoid downgrading)
+packages-no-deps = [
     "mcp-coder @ git+https://github.com/MarcusJellinghaus/mcp_coder.git",
 ]
 


### PR DESCRIPTION
## Summary
- Replace verbose `pip show` + `findstr` parsing in `claude_local.bat` and `icoder_local.bat` with a one-liner Python `importlib.metadata` check for editable installs
- Move `mcp-tools-py` from `packages-no-deps` to `packages` in `pyproject.toml` so it picks up external dependencies like jedi

## Test plan
- [ ] Run `claude_local.bat` and verify editable-install warning behaves correctly
- [ ] Run `icoder_local.bat` and verify editable-install warning behaves correctly
- [ ] Verify `mcp-tools-py` installs correctly with deps via `pip install`