### PR TITLE
fix(skill): resolve sleep TODOs in issue_analyse skill

### DIFF
--- a/.claude/skills/issue_analyse/SKILL.md
+++ b/.claude/skills/issue_analyse/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools:
   - mcp__workspace__git
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
+  - mcp__tools-py__sleep
 ---
 
 # Analyse GitHub Issue
@@ -19,6 +20,8 @@ The user may provide an issue number as the argument (available as `$ARGUMENTS`)
 If no issue number is provided:
 1. Read `.vscodeclaude_status.txt` and extract the issue number from the `Issue #NNN` line
 2. If the file doesn't exist or has no issue number, ask the user
+
+Wait one second using `mcp__tools-py__sleep` with `seconds: 1`
 
 Fetch the issue using `mcp__workspace__github_issue_view`.
 


### PR DESCRIPTION
## Summary
- Added `mcp__tools-py__sleep` to the allowed-tools list in the issue_analyse skill
- Updated the instruction to reference the sleep tool with proper parameters

## Test plan
- [ ] Verify `/issue_analyse` skill runs without errors when no issue number is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)