### PR TITLE
fix: add pytest to typecheck extra for CI mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     # "mcp-tools-py",  # TODO: uncomment once mcp-tools-py is published on PyPI
     # "mcp-coder",  # TODO: uncomment once mcp-coder is published on PyPI
 ]
-typecheck = ["mypy>=1.13.0", "types-requests>=2.31.0"]
+typecheck = ["mypy>=1.13.0", "types-requests>=2.31.0", "pytest>=8.3.5", "pytest-asyncio>=0.25.3"]
 architecture = [
     "import-linter>=2.0",
     "tach>=0.6.0",


### PR DESCRIPTION
## Summary
- The `upstream-mypy-check` CI workflow installs only the `typecheck` extra, which was missing `pytest` and `pytest-asyncio`
- Without pytest installed, mypy cannot resolve pytest decorator types (`@pytest.fixture`, `@pytest.mark.parametrize`, etc.), producing 118 false-positive `[untyped-decorator]` errors
- Adds `pytest>=8.3.5` and `pytest-asyncio>=0.25.3` to the `typecheck` extra so CI has the same type information as local dev

## Test plan
- [x] Verify `upstream-mypy-check` workflow passes after merge
- [x] Confirm local `mypy --strict src tests` still passes