### PR TITLE
fix(packaging): drop direct git URL dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           - {name: "unit-tests", cmd: "pytest --version && pytest -n auto -m 'not git_integration and not github_integration'"}
           - {name: "git-integration-tests", cmd: "pytest --version && pytest -n auto -m 'git_integration'"}
           - {name: "mypy", cmd: "mypy --version && mypy --strict src tests"}
+          - {name: "no-url-deps", cmd: "python tools/check_no_url_deps.py"}
 
     name: ${{ matrix.check.name }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "igittigitt>=2.1.5",
     "mcp>=1.3.0",
     "GitPython>=3.1.0",
-    "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git",
+    "mcp-coder-utils",
     "PyGithub>=1.59.0",
     "truststore",
 ]
@@ -93,6 +93,13 @@ target-version = ["py311"]
 profile = "black"
 line_length = 88
 float_to_top = true
+
+[tool.uv.sources]
+# Map sibling MCP packages to their GitHub sources so uv can satisfy the
+# plain-named dependency (mcp-coder-utils) above without listing it as a
+# direct URL dep in [project] (which PyPI rejects). uv-specific keys are
+# stripped from built wheels/sdists.
+mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
 
 [tool.mcp-coder.install-from-github]
 # Installed WITH deps (picks up external deps like jedi)

--- a/tools/check_no_url_deps.py
+++ b/tools/check_no_url_deps.py
@@ -1,0 +1,52 @@
+"""Fail if pyproject.toml [project] dependencies contain direct URL specs.
+
+Direct URL dependencies (e.g. ``pkg @ git+https://...``) are not allowed in
+``[project].dependencies`` or ``[project.optional-dependencies]``. PyPI and
+``twine check`` reject sdists/wheels that include them, and they make the
+project install non-portable.
+
+Use ``[tool.mcp-coder.install-from-github]`` for pre-installing GitHub
+sources via ``tools/reinstall_local.bat`` and the CI install step instead.
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+def main() -> int:
+    """Return 1 if any direct URL dependency is found, else 0."""
+    project_dir = Path(__file__).resolve().parent.parent
+    path = project_dir / "pyproject.toml"
+
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    project = data.get("project", {})
+    sources: list[tuple[str, str]] = []
+    for dep in project.get("dependencies", []):
+        sources.append(("dependencies", dep))
+    for group, items in project.get("optional-dependencies", {}).items():
+        for dep in items:
+            sources.append((f"optional-dependencies.{group}", dep))
+
+    bad = [
+        (loc, dep)
+        for loc, dep in sources
+        if "git+" in dep or " @ http" in dep or " @ file" in dep
+    ]
+
+    if bad:
+        print("ERROR: direct URL dependencies are not allowed:")
+        for loc, dep in bad:
+            print(f"  [{loc}] {dep}")
+        print()
+        print("Use [tool.mcp-coder.install-from-github] for git installs.")
+        return 1
+
+    print("OK: no direct URL dependencies in [project]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
PyPI's legacy upload endpoint rejects sdists/wheels whose core-metadata Requires-Dist contains direct URL deps, which broke the publish CI for 0.1.11.

- Replace `mcp-coder-utils @ git+https://...` in [project] dependencies with the plain name `mcp-coder-utils`.
- Add [tool.uv.sources] mapping so uv-based dev installs still resolve from GitHub. uv source keys are stripped from built artifacts and never reach published metadata.
- Add tools/check_no_url_deps.py and a matching `no-url-deps` CI matrix entry to catch any future direct URL dep at PR time instead of release time.