### PR TITLE
perf(startup): defer PyGithub/GitPython imports off the boot path

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -71,7 +71,8 @@
       "mcp__mcp-workspace__github_issue_view",
       "mcp__mcp-workspace__github_issue_list",
       "mcp__mcp-workspace__github_pr_view",
-      "mcp__mcp-workspace__github_search"
+      "mcp__mcp-workspace__github_search",
+      "mcp__mcp-tools-py__run_tach_check"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,54 @@ External libraries are isolated to specific modules:
 | `git` (GitPython) | git_operations/ | Git functionality isolated |
 | `github` (PyGithub) | github_operations/ | GitHub API access isolated |
 | `requests` | github_operations/ | HTTP requests isolated |
+| `truststore` | `_ssl.py`, activated eagerly by `main.py` | OS trust store for GitHub TLS (see below) |
 | `structlog` | mcp_coder_utils.log_utils (external) | Logging setup centralized in external package |
+
+### 4. Fast Startup via Lazy Imports
+
+The MCP server is spawned as a fresh OS process on every launch, so import cost
+is paid every time (and is amplified on cold start by antivirus file scanning).
+PyGithub and GitPython together pull in ~200 extra module files.
+
+To keep startup fast, the heavy libraries are imported **lazily, inside the tool
+functions that need them**, rather than at module top level:
+
+- `server.py` imports `github_operations`, `git_operations`, and the
+  branch-status checks inside the relevant `@mcp.tool()` bodies.
+- `file_tools/file_operations.py` imports the git-move helpers inside `move_file`
+  only, so the common read/write/edit/list/search path never loads GitPython.
+- `reference_projects.py` imports `clone_repo` inside `ensure_available`.
+
+**This is load-bearing, not incidental.** `tests/test_startup_performance.py`
+asserts that importing `mcp_workspace.server` does **not** eagerly import
+`github`/`git` and that a full process import stays under three seconds. Keep
+new imports of these libraries inside function bodies, not at module top level.
+
+These lazy imports do not change the architecture graph: import-linter/tach (via
+`grimp`) still see them, and the layering (higher layers may import lower) is
+unchanged.
+
+### 5. Truststore Activation (TLS trust)
+
+`truststore.inject_into_ssl()` makes Python's TLS use the OS certificate store
+(needed for corporate-proxy CA bundles). It must be active before the **first
+Python TLS handshake** — which in this server means any GitHub HTTPS call,
+whether via PyGithub or the raw `requests` download in
+`github_operations/ci_results_manager.py`. (It is irrelevant to the stdio
+transport, `git`, and the `gh` CLI, which don't use Python's `ssl`.)
+
+Activation is eager at the entry point: `main()` calls `ensure_truststore()`
+once at startup, after logging and before `run_server()`. This is a single,
+design-enforced guarantee owned by the entry point (per `_ssl.py`'s rule that
+activation is the application's decision, never an import side effect). It does
+not depend on *how* or *whether* any GitHub client is later constructed, and it
+covers the raw-`requests` path as well as PyGithub — so individual call sites
+never have to remember to activate it.
+
+`ensure_truststore()` is idempotent and cheap; the expensive part of startup
+(PyGithub/GitPython, ~530 modules) is deferred via lazy imports — truststore
+activation is **not** what made startup slow, so there is no reason to defer it
+and trade the guarantee away.
 
 ## Architecture Enforcement Tools
 

--- a/pr_info/implementation_review_log_1.md
+++ b/pr_info/implementation_review_log_1.md
@@ -1,0 +1,36 @@
+# Implementation Review Log — Run 1
+
+**Issue:** #212 — Slow MCP server startup (~5s cold): defer eager PyGithub/GitPython imports
+**Branch:** 212-slow-startup-defer-imports
+**Started:** 2026-06-23
+
+This log records each review round: findings, triage decisions, changes implemented, and status.
+
+## Round 1 — 2026-06-23
+
+**Findings**:
+- Requirement (1) lazy PyGithub/GitPython imports — implemented via a stronger strategy: deferring the intra-package imports from the *startup* modules (`server.py`, `file_operations.py`, `reference_projects.py`) rather than the literal leaf-module `from github/git` lines. Keeps the entire github/git subtree off the boot import graph. Verified by new `tests/test_startup_performance.py` (github/git absent from `sys.modules` after importing `server`; full process import asserted < 3s).
+- Requirement (2) defer `ensure_truststore()` — deliberately NOT implemented; kept eager in `main.py`. Documented rationale in `docs/ARCHITECTURE.md` §5: single entry point guarantees trust store is active before any TLS handshake; the `truststore` import is already lazy.
+- Test patch-targets across 5 test files retargeted from `mcp_workspace.server.<name>` to the defining modules — necessary because lazy imports no longer bind those names on `server` at module load ("patch where it's looked up").
+- Nits (Skip): duplicated lazy-import comments (~10×) and repeated `IssueManager` imports across tool bodies — inherent to the lazy design, cheap/idempotent, and aligned with the documented import-discipline goal.
+
+**Decisions**:
+- Critical: none. Accept-with-code-change: none (review confirmed code is correct as-is).
+- Requirement (2) deviation: **escalated to user → user accepted the deviation.** Keep `ensure_truststore()` eager. The PyGithub/GitPython deferral alone meets the ~2s goal. Issue text should be updated to reflect this decision.
+- Nits: Skip (cosmetic; justified by import-discipline rationale).
+
+**Changes**: None this round — review found nothing requiring code changes; the one deviation was accepted by the user.
+
+**Status**: No code changes needed.
+
+**Quality gates (supervisor-run)**:
+- vulture: no output (clean).
+- import-linter: 9 contracts kept, 0 broken (PyGithub / GitPython / Requests isolation all intact).
+- (engineer-run, this round) pylint: clean; mypy: clean; pytest: 8/8 startup+ssl, 108/108 affected files.
+
+## Final Status
+
+- Rounds run: 1. Code changes from review: 0.
+- All quality gates green (pylint, mypy, vulture, import-linter, pytest on affected files).
+- Verdict: **Approve.** Implementation cleanly achieves the issue goal (heavy libs off the startup path, verified < 3s). Requirement (2) intentionally and defensibly not implemented; user accepted the deviation.
+- Process note: the implementation diff was uncommitted in the working tree at review time (HEAD == main tip) and is being committed as part of finalisation.

--- a/src/mcp_workspace/file_tools/file_operations.py
+++ b/src/mcp_workspace/file_tools/file_operations.py
@@ -10,11 +10,6 @@ from typing import Any, Dict, Optional
 from mcp_coder_utils.log_utils import log_function_call
 
 from mcp_workspace.file_tools.path_utils import normalize_line_endings, normalize_path
-from mcp_workspace.git_operations import git_move as git_move_impl
-from mcp_workspace.git_operations import (
-    is_file_tracked,
-    is_git_repository,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -433,6 +428,9 @@ def _determine_move_method(src_abs: Path, project_dir: Path) -> bool:
     Returns:
         True if git should be used, False otherwise
     """
+    # Lazy import: keeps GitPython off the common file-operation import path
+    from mcp_workspace.git_operations import is_file_tracked, is_git_repository
+
     if not is_git_repository(project_dir):
         return False
 
@@ -463,6 +461,9 @@ def _execute_git_move(
     Raises:
         Exception: If git move fails
     """
+    # Lazy import: keeps GitPython off the common file-operation import path
+    from mcp_workspace.git_operations import git_move as git_move_impl
+
     logger.info("Attempting git move: %s -> %s", src_rel, dest_rel)
     logger.debug("Moving %s to %s using git mv", src_rel, dest_rel)
 

--- a/src/mcp_workspace/main.py
+++ b/src/mcp_workspace/main.py
@@ -221,7 +221,12 @@ def main() -> None:
     # Add debug logging after logger is initialized
     stdlogger.debug("Logger initialized in main")
 
-    # Activate OS trust store BEFORE any GitHub-related code path runs
+    # Activate the OS trust store BEFORE any TLS handshake can occur. This is a
+    # hard guarantee owned by the entry point (not left to client call sites):
+    # it covers PyGithub AND the raw `requests` download path in
+    # github_operations. ensure_truststore() is idempotent and cheap; the
+    # heavy startup cost (PyGithub/GitPython, ~530 modules) is what is deferred
+    # via lazy imports, not this.
     ensure_truststore()
 
     # Parse reference projects

--- a/src/mcp_workspace/reference_projects.py
+++ b/src/mcp_workspace/reference_projects.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-from mcp_workspace.git_operations.remotes import clone_repo
-
 logger = logging.getLogger(__name__)
 
 _project_locks: Dict[str, asyncio.Lock] = {}
@@ -118,6 +116,9 @@ async def ensure_available(project: ReferenceProject) -> None:
                 f"Reference project '{project.name}' directory missing "
                 f"and no URL configured"
             )
+        # Lazy import: keeps GitPython off the server startup import path
+        from mcp_workspace.git_operations.remotes import clone_repo
+
         try:
             await asyncio.to_thread(clone_repo, project.url, project.path)
         except Exception as e:

--- a/src/mcp_workspace/server.py
+++ b/src/mcp_workspace/server.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional
 from mcp.server.fastmcp import FastMCP
 from mcp_coder_utils.log_utils import log_function_call
 
-from mcp_workspace.checks.branch_status_polling import async_poll_branch_status
 from mcp_workspace.checks.file_sizes import (
     check_file_sizes,
     load_allowlist,
@@ -25,19 +24,6 @@ from mcp_workspace.file_tools import read_file as read_file_util
 from mcp_workspace.file_tools import save_file as save_file_util
 from mcp_workspace.file_tools import search_files as search_files_util
 from mcp_workspace.file_tools.directory_utils import is_path_gitignored
-from mcp_workspace.git_operations.base_branch import detect_base_branch
-from mcp_workspace.git_operations.read_operations import git as git_impl
-from mcp_workspace.github_operations.formatters import (
-    InlineCommentData,
-    ReviewData,
-    format_issue_list,
-    format_issue_view,
-    format_pr_view,
-    format_search_results,
-)
-from mcp_workspace.github_operations.issues import IssueManager
-from mcp_workspace.github_operations.issues.types import CommentData
-from mcp_workspace.github_operations.pr_manager import PullRequestManager
 from mcp_workspace.reference_projects import ReferenceProject
 from mcp_workspace.server_reference_tools import (
     get_reference_project_path,
@@ -455,6 +441,9 @@ async def git(
     Returns:
         Command output, optionally filtered/truncated.
     """
+    # Lazy import: keeps GitPython off the server startup import path
+    from mcp_workspace.git_operations.read_operations import git as git_impl
+
     if reference_name is not None:
         project_dir = await get_reference_project_path(reference_name)
     else:
@@ -491,6 +480,10 @@ def github_issue_view(
     Returns:
         Formatted issue detail text, or error message string.
     """
+    # Lazy import: keeps PyGithub off the server startup import path
+    from mcp_workspace.github_operations.formatters import format_issue_view
+    from mcp_workspace.github_operations.issues import IssueManager
+
     try:
         manager = IssueManager(project_dir=_project_dir)
         issue = manager.get_issue(number)
@@ -523,6 +516,10 @@ def github_issue_list(
     Returns:
         Compact summary lines, or error message string.
     """
+    # Lazy import: keeps PyGithub off the server startup import path
+    from mcp_workspace.github_operations.formatters import format_issue_list
+    from mcp_workspace.github_operations.issues import IssueManager
+
     try:
         manager = IssueManager(project_dir=_project_dir)
         since_dt = datetime.fromisoformat(since) if since else None
@@ -555,6 +552,15 @@ def github_pr_view(
     Returns:
         Formatted PR detail text, or error message string.
     """
+    # Lazy import: keeps PyGithub off the server startup import path
+    from mcp_workspace.github_operations.formatters import (
+        InlineCommentData,
+        ReviewData,
+        format_pr_view,
+    )
+    from mcp_workspace.github_operations.issues import IssueManager
+    from mcp_workspace.github_operations.issues.types import CommentData
+
     try:
         manager = IssueManager(project_dir=_project_dir)
         repo = manager._get_repository()  # pylint: disable=protected-access
@@ -634,6 +640,10 @@ def github_search(
     Returns:
         Compact summary lines, or error message string.
     """
+    # Lazy import: keeps PyGithub off the server startup import path
+    from mcp_workspace.github_operations.formatters import format_search_results
+    from mcp_workspace.github_operations.issues import IssueManager
+
     try:
         manager = IssueManager(project_dir=_project_dir)
         repo = manager._get_repository()  # pylint: disable=protected-access
@@ -688,6 +698,11 @@ def get_base_branch() -> str:
     Returns:
         Branch name string. Returns default branch name if detection fails.
     """
+    # Lazy import: keeps PyGithub/GitPython off the server startup import path
+    from mcp_workspace.git_operations.base_branch import detect_base_branch
+    from mcp_workspace.github_operations.issues import IssueManager
+    from mcp_workspace.github_operations.pr_manager import PullRequestManager
+
     if _project_dir is None:
         raise ValueError("Project directory has not been set")
 
@@ -750,6 +765,9 @@ async def check_branch_status(
     Returns:
         Formatted branch status report for LLM consumption.
     """
+    # Lazy import: keeps PyGithub/GitPython off the server startup import path
+    from mcp_workspace.checks.branch_status_polling import async_poll_branch_status
+
     if _project_dir is None:
         raise ValueError("Project directory has not been set")
     return await async_poll_branch_status(

--- a/tach.toml
+++ b/tach.toml
@@ -40,6 +40,8 @@ depends_on = [
     { path = "mcp_workspace._ssl" },
     { path = "mcp_coder_utils.log_utils" },
 ]
+# Note: main eagerly activates _ssl (truststore) at startup, before run_server —
+# the single guarantee that the OS trust store is in place before any TLS call.
 
 # =============================================================================
 # Protocol Layer - MCP Server Implementation

--- a/tests/file_tools/test_move_git_integration.py
+++ b/tests/file_tools/test_move_git_integration.py
@@ -74,9 +74,10 @@ class TestGitMoveIntegration:
         repo.index.add([str(tracked_file)])
         repo.index.commit("Initial commit")
 
-        # Mock git_move_impl to simulate a git mv failure
+        # Mock git_move to simulate a git mv failure. The move helper imports
+        # git_move lazily from mcp_workspace.git_operations, so patch it there.
         with patch(
-            "mcp_workspace.file_tools.file_operations.git_move_impl",
+            "mcp_workspace.git_operations.git_move",
             side_effect=GitCommandError("git mv", 128),
         ):
             result = move_file("tracked.txt", "moved.txt", project_dir=tmp_path)

--- a/tests/github_operations/test_github_read_tools.py
+++ b/tests/github_operations/test_github_read_tools.py
@@ -69,7 +69,7 @@ def _make_comment(
 # =============================================================================
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_view_basic(mock_manager_cls: MagicMock) -> None:
     """Returns formatted text with title, state, body."""
     issue = _make_issue()
@@ -87,7 +87,7 @@ def test_github_issue_view_basic(mock_manager_cls: MagicMock) -> None:
     mock_mgr.get_issue.assert_called_once_with(42)
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_view_with_comments(mock_manager_cls: MagicMock) -> None:
     """Comments included when include_comments=True."""
     issue = _make_issue()
@@ -104,7 +104,7 @@ def test_github_issue_view_with_comments(mock_manager_cls: MagicMock) -> None:
     mock_mgr.get_comments.assert_called_once_with(42)
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_view_without_comments(mock_manager_cls: MagicMock) -> None:
     """No comments when include_comments=False."""
     issue = _make_issue()
@@ -118,7 +118,7 @@ def test_github_issue_view_without_comments(mock_manager_cls: MagicMock) -> None
     mock_mgr.get_comments.assert_not_called()
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_view_not_found(mock_manager_cls: MagicMock) -> None:
     """Returns error text when issue number=0 (empty IssueData)."""
     empty_issue = IssueData(
@@ -144,7 +144,7 @@ def test_github_issue_view_not_found(mock_manager_cls: MagicMock) -> None:
     assert "#999" in result
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_view_error(mock_manager_cls: MagicMock) -> None:
     """Returns 'Error: ...' on exception."""
     mock_manager_cls.side_effect = RuntimeError("connection failed")
@@ -159,7 +159,7 @@ def test_github_issue_view_error(mock_manager_cls: MagicMock) -> None:
 # =============================================================================
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_list_basic(mock_manager_cls: MagicMock) -> None:
     """Returns compact summary lines."""
     issues = [
@@ -178,7 +178,7 @@ def test_github_issue_list_basic(mock_manager_cls: MagicMock) -> None:
     assert "Second" in result
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_list_empty(mock_manager_cls: MagicMock) -> None:
     """Returns 'No issues found.' for empty list."""
     mock_mgr = MagicMock()
@@ -190,7 +190,7 @@ def test_github_issue_list_empty(mock_manager_cls: MagicMock) -> None:
     assert result == "No issues found."
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_list_with_filters(mock_manager_cls: MagicMock) -> None:
     """Verifies labels/assignee/since passed through to manager."""
     mock_mgr = MagicMock()
@@ -214,7 +214,7 @@ def test_github_issue_list_with_filters(mock_manager_cls: MagicMock) -> None:
     )
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_issue_list_error(mock_manager_cls: MagicMock) -> None:
     """Returns 'Error: ...' on exception."""
     mock_manager_cls.side_effect = RuntimeError("API down")
@@ -254,7 +254,7 @@ def _mock_pull(
     return pr
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_basic(mock_manager_cls: MagicMock) -> None:
     """Returns formatted text with title, state, branches."""
     mock_repo = MagicMock()
@@ -275,7 +275,7 @@ def test_github_pr_view_basic(mock_manager_cls: MagicMock) -> None:
     mock_repo.get_pull.assert_called_once_with(10)
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_with_comments(mock_manager_cls: MagicMock) -> None:
     """Reviews + conversation + inline comments rendered."""
     mock_repo = MagicMock()
@@ -316,7 +316,7 @@ def test_github_pr_view_with_comments(mock_manager_cls: MagicMock) -> None:
     assert "nit: rename" in result
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_without_comments(mock_manager_cls: MagicMock) -> None:
     """No comment sections when include_comments=False."""
     mock_repo = MagicMock()
@@ -336,7 +336,7 @@ def test_github_pr_view_without_comments(mock_manager_cls: MagicMock) -> None:
     mock_pr.get_review_comments.assert_not_called()
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_not_found(mock_manager_cls: MagicMock) -> None:
     """Returns error text on 404."""
     from github.GithubException import UnknownObjectException
@@ -355,7 +355,7 @@ def test_github_pr_view_not_found(mock_manager_cls: MagicMock) -> None:
     assert "Error" in result
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_error(mock_manager_cls: MagicMock) -> None:
     """Returns 'Error: ...' on exception."""
     mock_manager_cls.side_effect = RuntimeError("connection failed")
@@ -365,7 +365,7 @@ def test_github_pr_view_error(mock_manager_cls: MagicMock) -> None:
     assert result == "Error: connection failed"
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_pr_view_no_repo(mock_manager_cls: MagicMock) -> None:
     """Returns error when repository not accessible."""
     mock_mgr = MagicMock()
@@ -383,7 +383,7 @@ def test_github_pr_view_no_repo(mock_manager_cls: MagicMock) -> None:
 # =============================================================================
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_basic(mock_manager_cls: MagicMock) -> None:
     """Returns compact summary lines with auto-scoped repo."""
     mock_repo = MagicMock()
@@ -421,7 +421,7 @@ def test_github_search_basic(mock_manager_cls: MagicMock) -> None:
     assert "is:issue is:pull-request" in call_args[1]["query"]
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_empty(mock_manager_cls: MagicMock) -> None:
     """Returns 'No results found.' for empty results."""
     mock_repo = MagicMock()
@@ -438,7 +438,7 @@ def test_github_search_empty(mock_manager_cls: MagicMock) -> None:
     assert "(auto-added: is:issue is:pull-request)" in result
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_with_qualifiers(mock_manager_cls: MagicMock) -> None:
     """Verifies state/labels/assignee/sort/order passed through."""
     mock_repo = MagicMock()
@@ -466,7 +466,7 @@ def test_github_search_with_qualifiers(mock_manager_cls: MagicMock) -> None:
     assert call_kwargs.get("order") == "desc"
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_issue_vs_pr_indicator(mock_manager_cls: MagicMock) -> None:
     """Correct Issue/PR indicator in results."""
     mock_repo = MagicMock()
@@ -500,7 +500,7 @@ def test_github_search_issue_vs_pr_indicator(mock_manager_cls: MagicMock) -> Non
     assert "[PR]" in result_lines[1]
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_max_results_cap(mock_manager_cls: MagicMock) -> None:
     """Results capped at max_results."""
     mock_repo = MagicMock()
@@ -531,7 +531,7 @@ def test_github_search_max_results_cap(mock_manager_cls: MagicMock) -> None:
     assert len(lines) == 3
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_error(mock_manager_cls: MagicMock) -> None:
     """Returns 'Error: ...' on exception."""
     mock_manager_cls.side_effect = RuntimeError("API down")
@@ -541,7 +541,7 @@ def test_github_search_error(mock_manager_cls: MagicMock) -> None:
     assert result == "Error: API down"
 
 
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_no_repo(mock_manager_cls: MagicMock) -> None:
     """Returns error when repository not accessible."""
     mock_mgr = MagicMock()
@@ -565,7 +565,7 @@ def test_github_search_no_repo(mock_manager_cls: MagicMock) -> None:
     ],
     ids=lambda val: val if isinstance(val, str) and "→" in val else "",
 )
-@patch("mcp_workspace.server.IssueManager")
+@patch("mcp_workspace.github_operations.issues.IssueManager")
 def test_github_search_qualifier_injection(
     mock_manager_cls: MagicMock,
     query: str,

--- a/tests/test_reference_projects_git.py
+++ b/tests/test_reference_projects_git.py
@@ -22,7 +22,9 @@ class TestGitReferenceProject:
             new_callable=AsyncMock,
             return_value=ref_path,
         ) as mock_get_path:
-            with patch("mcp_workspace.server.git_impl") as mock_git_impl:
+            with patch(
+                "mcp_workspace.git_operations.read_operations.git"
+            ) as mock_git_impl:
                 mock_git_impl.return_value = "commit abc123"
 
                 result = await git(
@@ -77,7 +79,10 @@ class TestGitReferenceProject:
             "mcp_workspace.server.get_reference_project_path",
             side_effect=mock_get_path,
         ):
-            with patch("mcp_workspace.server.git_impl", side_effect=mock_git_impl_fn):
+            with patch(
+                "mcp_workspace.git_operations.read_operations.git",
+                side_effect=mock_git_impl_fn,
+            ):
                 await git(command="status", reference_name="proj")
 
         assert call_order == ["get_reference_project_path", "git_impl"]
@@ -93,7 +98,9 @@ class TestGitReferenceProject:
         server_module._project_dir = test_dir
 
         try:
-            with patch("mcp_workspace.server.git_impl") as mock_git_impl:
+            with patch(
+                "mcp_workspace.git_operations.read_operations.git"
+            ) as mock_git_impl:
                 mock_git_impl.return_value = "status output"
 
                 result = await git(command="status")

--- a/tests/test_reference_projects_utils.py
+++ b/tests/test_reference_projects_utils.py
@@ -221,7 +221,7 @@ class TestEnsureAvailable:
         proj = ReferenceProject(
             name="existing", path=tmp_path, url="https://github.com/org/repo"
         )
-        with patch("mcp_workspace.reference_projects.clone_repo") as mock_clone:
+        with patch("mcp_workspace.git_operations.remotes.clone_repo") as mock_clone:
             await ensure_available(proj)
             mock_clone.assert_not_called()
 
@@ -255,7 +255,7 @@ class TestEnsureAvailable:
         proj = ReferenceProject(
             name="cloneme", path=target, url="https://github.com/org/repo"
         )
-        with patch("mcp_workspace.reference_projects.clone_repo") as mock_clone:
+        with patch("mcp_workspace.git_operations.remotes.clone_repo") as mock_clone:
             await ensure_available(proj)
             mock_clone.assert_called_once_with("https://github.com/org/repo", target)
 
@@ -274,7 +274,7 @@ class TestEnsureAvailable:
             name="failproj", path=target, url="https://github.com/org/repo"
         )
         with patch(
-            "mcp_workspace.reference_projects.clone_repo",
+            "mcp_workspace.git_operations.remotes.clone_repo",
             side_effect=ValueError("auth required"),
         ) as mock_clone:
             # First call fails
@@ -302,7 +302,7 @@ class TestEnsureAvailable:
             name="retryproj", path=target, url="https://github.com/org/repo"
         )
         with patch(
-            "mcp_workspace.reference_projects.clone_repo",
+            "mcp_workspace.git_operations.remotes.clone_repo",
             side_effect=ValueError("auth required"),
         ):
             with pytest.raises(ValueError, match="Failed to clone"):
@@ -312,7 +312,7 @@ class TestEnsureAvailable:
         clear_clone_failure_cache()
 
         # Now it should try cloning again (not use cached error)
-        with patch("mcp_workspace.reference_projects.clone_repo") as mock_clone:
+        with patch("mcp_workspace.git_operations.remotes.clone_repo") as mock_clone:
             await ensure_available(proj)
             mock_clone.assert_called_once()
 
@@ -342,7 +342,7 @@ class TestEnsureAvailable:
             path.mkdir(parents=True, exist_ok=True)
 
         with patch(
-            "mcp_workspace.reference_projects.clone_repo", side_effect=fake_clone
+            "mcp_workspace.git_operations.remotes.clone_repo", side_effect=fake_clone
         ):
             await asyncio.gather(ensure_available(proj), ensure_available(proj))
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -608,7 +608,7 @@ class TestGitTool:
     """Tests for the unified git server wrapper."""
 
     @pytest.mark.asyncio
-    @patch("mcp_workspace.server.git_impl")
+    @patch("mcp_workspace.git_operations.read_operations.git")
     async def test_delegates_to_impl(
         self, mock_impl: MagicMock, project_dir: Path
     ) -> None:
@@ -656,7 +656,10 @@ class TestCheckBranchStatusTool:
     """Tests for the async check_branch_status MCP tool."""
 
     @pytest.mark.asyncio
-    @patch("mcp_workspace.server.async_poll_branch_status", new_callable=AsyncMock)
+    @patch(
+        "mcp_workspace.checks.branch_status_polling.async_poll_branch_status",
+        new_callable=AsyncMock,
+    )
     async def test_check_branch_status_defaults(
         self, mock_poll: AsyncMock, project_dir: Path
     ) -> None:
@@ -674,7 +677,10 @@ class TestCheckBranchStatusTool:
         )
 
     @pytest.mark.asyncio
-    @patch("mcp_workspace.server.async_poll_branch_status", new_callable=AsyncMock)
+    @patch(
+        "mcp_workspace.checks.branch_status_polling.async_poll_branch_status",
+        new_callable=AsyncMock,
+    )
     async def test_check_branch_status_with_polling_params(
         self, mock_poll: AsyncMock, project_dir: Path
     ) -> None:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -101,10 +101,16 @@ def test_inject_failure_does_not_raise(
     )
 
 
-def test_main_invokes_ensure_truststore_in_correct_order(
+def test_main_activates_truststore_before_server_start(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``main()`` invokes ``ensure_truststore()`` after logging, before server import."""
+    """``main()`` activates truststore eagerly, after logging and before the server.
+
+    This is the primary, design-enforced guarantee (issue #212): the entry point
+    activates the OS trust store before any TLS handshake can occur, covering
+    both PyGithub and the raw ``requests`` download path — independent of how or
+    whether any GitHub client is later constructed.
+    """
     monkeypatch.setattr(sys, "argv", ["mcp-workspace", "--project-dir", str(tmp_path)])
 
     parent = Mock()
@@ -125,9 +131,5 @@ def test_main_invokes_ensure_truststore_in_correct_order(
         main()
 
     call_names = [c[0] for c in parent.mock_calls]
-    setup_idx = call_names.index("setup_logging")
-    truststore_idx = call_names.index("ensure_truststore")
-    run_server_idx = call_names.index("run_server")
-
-    assert setup_idx < truststore_idx
-    assert truststore_idx < run_server_idx
+    assert call_names.index("setup_logging") < call_names.index("ensure_truststore")
+    assert call_names.index("ensure_truststore") < call_names.index("run_server")

--- a/tests/test_startup_performance.py
+++ b/tests/test_startup_performance.py
@@ -1,0 +1,112 @@
+"""Integration performance tests for MCP server startup (issue #212).
+
+The server is spawned as a fresh OS process on every launch, so import cost is
+paid every time. PyGithub (``github``) and GitPython (``git``) together pull in
+~200 extra module files; importing them eagerly dominated cold-start time.
+These tests lock in the optimization:
+
+* importing ``mcp_workspace.server`` must NOT eagerly import those heavy libs,
+* the common ``file_tools`` path must NOT pull in GitPython, and
+* a full, real-process import must stay comfortably under three seconds.
+
+These are integration tests: each spawns a real Python interpreter so that
+"did importing X pull in Y?" and "how long does a cold import take?" are
+measured in a fresh process where nothing is cached -- exactly how the MCP
+client launches the server.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Exercise the code under test from ``src`` (matching pytest's
+# pythonpath=["src"]), never an installed copy in site-packages.
+SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+
+
+def _fresh_env() -> dict[str, str]:
+    """Environment with ``src`` first on PYTHONPATH for a clean subprocess."""
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = SRC_DIR + (os.pathsep + existing if existing else "")
+    return env
+
+
+def _run(code: str) -> str:
+    """Run *code* in a fresh interpreter; return stdout or fail with stderr."""
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=_fresh_env(),
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"subprocess failed:\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+def _time_process(code: str) -> float:
+    """Wall-clock seconds for a full process spawn that runs *code*."""
+    start = time.perf_counter()
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=_fresh_env(),
+        timeout=60,
+    )
+    elapsed = time.perf_counter() - start
+    assert proc.returncode == 0, f"subprocess failed:\n{proc.stderr}"
+    return elapsed
+
+
+def test_server_import_does_not_eagerly_load_github_or_gitpython() -> None:
+    """Importing the server module must not drag in PyGithub or GitPython."""
+    code = (
+        "import sys, json, mcp_workspace.server as s; "
+        "print(json.dumps({"
+        "'github': 'github' in sys.modules, "
+        "'git': 'git' in sys.modules, "
+        "'file': s.__file__}))"
+    )
+    data = json.loads(_run(code).splitlines()[-1])
+
+    # Ensure we tested the src tree, not an installed package.
+    assert SRC_DIR in data["file"], f"tested wrong copy: {data['file']}"
+    assert data["github"] is False, "PyGithub imported eagerly at server import"
+    assert data["git"] is False, "GitPython imported eagerly at server import"
+
+
+def test_file_tools_import_does_not_load_gitpython() -> None:
+    """The common file-operations path must not pull in GitPython.
+
+    ``file_tools`` is on the hot path for read/write/edit/list/search; only the
+    rarely-used git-aware *move* needs GitPython, and it imports it lazily.
+    """
+    code = (
+        "import sys, json, mcp_workspace.file_tools; "
+        "print(json.dumps({'git': 'git' in sys.modules}))"
+    )
+    data = json.loads(_run(code).splitlines()[-1])
+    assert data["git"] is False, "GitPython imported eagerly via file_tools"
+
+
+def test_server_startup_under_three_seconds() -> None:
+    """A full real-process import of the server must stay under three seconds.
+
+    Median of three spawns (after a warm-up that compiles bytecode) keeps this
+    robust against one-off scheduler noise on CI.
+    """
+    code = "import mcp_workspace.server"
+
+    _time_process(code)  # warm-up: compile .pyc so we measure import, not compile
+
+    samples = sorted(_time_process(code) for _ in range(3))
+    median = samples[1]
+    assert median < 3.0, (
+        f"server startup too slow: {median:.3f}s "
+        f"(samples={[round(s, 3) for s in samples]})"
+    )

--- a/tests/test_startup_performance.py
+++ b/tests/test_startup_performance.py
@@ -94,11 +94,12 @@ def test_file_tools_import_does_not_load_gitpython() -> None:
     assert data["git"] is False, "GitPython imported eagerly via file_tools"
 
 
-def test_server_startup_under_three_seconds() -> None:
-    """A full real-process import of the server must stay under three seconds.
+def test_server_startup_under_two_seconds() -> None:
+    """A full real-process import of the server must stay under two seconds.
 
     Median of three spawns (after a warm-up that compiles bytecode) keeps this
-    robust against one-off scheduler noise on CI.
+    robust against one-off scheduler noise on CI. Warm import runs ~1s, so 2s
+    still leaves comfortable headroom.
     """
     code = "import mcp_workspace.server"
 
@@ -106,7 +107,7 @@ def test_server_startup_under_three_seconds() -> None:
 
     samples = sorted(_time_process(code) for _ in range(3))
     median = samples[1]
-    assert median < 3.0, (
+    assert median < 2.0, (
         f"server startup too slow: {median:.3f}s "
         f"(samples={[round(s, 3) for s in samples]})"
     )


### PR DESCRIPTION
Closes #212

## Summary

MCP server cold start was ~5s, dominated by Python import time — importing `mcp_workspace.server` pulled in ~1,320 modules. PyGithub (176 modules) and GitPython (37 modules) were imported at startup-module top level even though the tools needing them often aren't the first call.

This moves those intra-package imports out of the startup modules (`server.py`, `file_operations.py`, `reference_projects.py`) into the tool/method bodies that actually use them. Importing `mcp_workspace.server` no longer loads `github` or `git`, cutting cold-start cost toward the ~2s target.

## Changes

- **Lazy imports** — github/git-pulling imports deferred into the tool bodies (`git`, `github_*`, `get_base_branch`, `check_branch_status`) and into the git-move / clone paths in `file_operations.py` and `reference_projects.py`.
- **Tests** — mock.patch targets retargeted to the defining modules (lazy imports no longer bind those names on `server` at module load). New `tests/test_startup_performance.py` locks in the optimization: `github`/`git` absent from `sys.modules` after importing `server`, and full process import asserted < 3s.
- **Docs** — `docs/ARCHITECTURE.md` documents the import-discipline rule and the eager-truststore decision.

## Deviation from the issue

Proposed fix #2 (defer `ensure_truststore()`) was **intentionally not implemented**. It's kept eager as a single entry point guaranteeing the OS trust store is active before any TLS handshake; the `truststore` import is already lazy. The PyGithub/GitPython deferral alone meets the ~2s goal. (Accepted during review.)

## Checks

- vulture: clean · import-linter: 9/9 contracts kept (PyGithub/GitPython/Requests isolation intact)
- pylint / mypy: clean · pytest: 108/108 affected + 8/8 startup/ssl