### PR TITLE
chore(ci): bump repository-dispatch to v4 (Node 24)

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send upstream-main-updated to mcp_coder
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DOWNSTREAM_PAT }}
           repository: MarcusJellinghaus/mcp_coder


### PR DESCRIPTION
## What

Bumps `peter-evans/repository-dispatch` from `@v3` to `@v4` in `notify-downstream.yml`.

## Why

`@v3` runs on the deprecated Node 20 runtime, producing a deprecation warning on every push to `main`. `v4.0.1` runs on `node24`, clearing the warning. Action inputs are unchanged.

## Notes

- This does **not** fix the separate `Bad credentials` failure in that workflow, which is caused by an expired/missing `DOWNSTREAM_PAT` secret.
- Reviewed all other actions in CI: none are on Node 20. Three are a major behind latest (`github-script`, `checkout`, `setup-uv`) but already run on node24, so were intentionally left as-is.