### PR TITLE
chore: delete dormant [tool.uv.sources] block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,13 +94,6 @@ profile = "black"
 line_length = 88
 float_to_top = true
 
-[tool.uv.sources]
-# Map sibling MCP packages to their GitHub sources so uv can satisfy the
-# plain-named dependency (mcp-coder-utils) above without listing it as a
-# direct URL dep in [project] (which PyPI rejects). uv-specific keys are
-# stripped from built wheels/sdists.
-mcp-coder-utils = { git = "https://github.com/MarcusJellinghaus/mcp-coder-utils.git" }
-
 [tool.mcp-coder.install-from-github]
 # Installed WITH deps (picks up external deps like jedi)
 packages = [


### PR DESCRIPTION
Part of #72.

Deletes the dormant `[tool.uv.sources]` block from `pyproject.toml` — leftover from the cancelled `uv sync` migration ([mcp_coder#969](https://github.com/MarcusJellinghaus/mcp_coder/issues/969)).

Nothing consults it anymore:
- CI installs via `uv pip install`, which ignores `tool.uv.sources`.
- `mcp-coder-utils` is published on PyPI (0.1.5), so the plain-name dependency resolves without a source mapping.
- Latest-from-git installs go through `[tool.mcp-coder.install-from-github]`.
